### PR TITLE
Update window_utils.py

### DIFF
--- a/georeader/window_utils.py
+++ b/georeader/window_utils.py
@@ -5,7 +5,6 @@ import numbers
 import numpy as np
 from shapely.geometry import Polygon, MultiPolygon, shape, mapping
 import rasterio.warp
-from georeader import compare_crs
 import math
 
 PIXEL_PRECISION = 3


### PR DESCRIPTION
Remove the "from georeader import compare_crs" line. This lead to a "compare_crs not found" error when the georeader.window_utils module was used. However, compare_crs module isn't acessed in the window_utils file at all.