### PR TITLE
Bugfix of `rasterio_reader.RasterioReader.reader_overview`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "georeader-spaceml"
-version = "1.3.15"
+version = "1.3.16"
 description = "🛰️ Process raster data in python"
 authors = ["Gonzalo Mateo-García", "Kike Portales", "Manuel Montesino San Martin"]
 repository = "https://github.com/spaceml-org/georeader"


### PR DESCRIPTION
There's a bug in the `reader_overview()` function of the `RasterioReader` class that was passing the `self.window_focus` object. Since the resolution of the raster changes we shall change the `window_focus` that is propagated. 

In most of the cases the `window_focus` is going to be the full image so in those cases constructing with `window_focus=None` and returning that object shall be good. For the moment I'm showing a warning if the `self.window_focus` is not the full tile.

In addition, I'm propagating the `rio_env_options` in the functions that return a `RasterioReader` object.