### PR TITLE
fix: handle NaN values in GLT coordinates by replacing with zeros.

### DIFF
--- a/georeader/readers/emit.py
+++ b/georeader/readers/emit.py
@@ -348,8 +348,8 @@ class EMITImage:
         if glt is None:
             # Open the location group to access glt_x and glt_y
             location_ds = safe_open_netcdf(self.filename, cache=False, load=False, group='location')
-            glt_x = location_ds['glt_x'].values
-            glt_y = location_ds['glt_y'].values
+            glt_x = np.nan_to_num(location_ds['glt_x'].values, nan=0).astype(np.int32)
+            glt_y = np.nan_to_num(location_ds['glt_y'].values, nan=0).astype(np.int32)
             location_ds.close()
             
             glt_arr = np.zeros((2,) + glt_x.shape, dtype=np.int32)


### PR DESCRIPTION
 Failing for product `EMIT_L1B_RAD_001_20260125T232556_2602515_010`  it was casting `np.nan` values to max int, that was failing. This seems to be a new change as for old products (e.g. `EMIT_L1B_RAD_001_20220827T060753_2223904_013`) the out of bounds values are set to zero. 

Now it seems that OOB values are nan but the glt is still 1-based indexed. So my fix consists in casting to maintain the old behaviour.

<img width="987" height="449" alt="image" src="https://github.com/user-attachments/assets/8b0430d4-2603-4de7-876b-cbced351baa7" />

