### PR TITLE
Replace VSIL cache workaround with rasterio.cache API

### DIFF
--- a/docs/advanced/error_read_write_in_remote_path.md
+++ b/docs/advanced/error_read_write_in_remote_path.md
@@ -226,13 +226,24 @@ data_rst
 fs.delete(filepath)
 ```
 
-Adding option  `read_with_CPL_VSIL_CURL_NON_CACHED` fixes the problem, we see that after the second copy the raster has 1 channel instead of 3.
+Adding option `invalidate_cache_before_open` fixes the problem by calling `rasterio.cache.invalidate()` before each open. After the second copy the raster has 1 channel instead of 3.
 
 
 ```python
 from georeader import rasterio_reader
-rasterio_reader.RIO_ENV_OPTIONS_DEFAULT["read_with_CPL_VSIL_CURL_NON_CACHED"] = True
+rasterio_reader.RIO_ENV_OPTIONS_DEFAULT["invalidate_cache_before_open"] = True
 ```
+
+You can also invalidate the cache explicitly on a reader instance:
+
+```python
+rst = RasterioReader(filepath)
+rst.invalidate_cache()  # clears cache for this reader's paths
+data = rst.load()
+```
+
+!!! note
+    The deprecated `read_with_CPL_VSIL_CURL_NON_CACHED` option still works but will emit a `DeprecationWarning`.
 
 
 ```python

--- a/georeader/geotensor.py
+++ b/georeader/geotensor.py
@@ -2,6 +2,7 @@
 import numpy as np
 from typing import Any, Dict, Union, Tuple, Optional, List
 import rasterio
+import rasterio.cache
 import rasterio.windows
 from georeader import window_utils
 from georeader.window_utils import window_bounds
@@ -36,38 +37,40 @@ RIO_ENV_OPTIONS_DEFAULT = dict(
     GDAL_HTTP_MULTIPLEX="YES"
 )
 
-def _vsi_path(path:str)->str:
-    """
-    Function to convert a path to a VSI path. We use this function to try re-reading the image 
-    disabling the VSI cache. This fixes the error when the remote file is modified from another
-    program.
+def _maybe_invalidate_cache(options:dict, path:str) -> Dict[str, str]:
+    """Process cache invalidation options and return clean GDAL options.
+
+    If ``invalidate_cache_before_open`` is True, calls
+    ``rasterio.cache.invalidate(path)`` to clear cached HTTP responses
+    for the given path before opening.
+
+    Also handles the deprecated ``read_with_CPL_VSIL_CURL_NON_CACHED`` key.
 
     Args:
-        - path: path to convert to VSI path
-    
+        options: Dict of rasterio.Env options.
+        path: The file path to potentially invalidate cache for.
+
     Returns:
-        VSI path
+        Copy of options with cache-control keys removed, safe to pass
+        to ``rasterio.Env``.
     """
-    if not "://" in path:
-        return path
-    
-    protocol, remainder_path = path.split("://")
-    
-    if path.startswith("http"):
-        return f"/vsicurl/{path}"
-    elif protocol in ["s3", "gs", "az", "oss"]:
-        return f"/vsi{protocol}/{remainder_path}"
-    else:
-        warnings.warn(f"Protocol {protocol} not recognized. Returning the original path")
-        return path
+    options = options.copy()
 
-
-def get_rio_options_path(options:dict, path:str) -> Dict[str, str]:
     if "read_with_CPL_VSIL_CURL_NON_CACHED" in options:
-        options = options.copy()
-        if options["read_with_CPL_VSIL_CURL_NON_CACHED"]:
-            options["CPL_VSIL_CURL_NON_CACHED"] = _vsi_path(path)
+        warnings.warn(
+            "'read_with_CPL_VSIL_CURL_NON_CACHED' is deprecated. "
+            "Use 'invalidate_cache_before_open' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if "invalidate_cache_before_open" not in options:
+            options["invalidate_cache_before_open"] = options["read_with_CPL_VSIL_CURL_NON_CACHED"]
         del options["read_with_CPL_VSIL_CURL_NON_CACHED"]
+
+    if options.pop("invalidate_cache_before_open", False):
+        if "://" in path:
+            rasterio.cache.invalidate(path)
+
     return options
 
 class GeoTensor:
@@ -704,7 +707,7 @@ class GeoTensor:
         tags = None
         descriptions = None
         rio_env_options = RIO_ENV_OPTIONS_DEFAULT if rio_env_options is None else rio_env_options
-        with rasterio.Env(**get_rio_options_path(rio_env_options, path)):
+        with rasterio.Env(**_maybe_invalidate_cache(rio_env_options, path)):
             with rasterio.open(path) as src:                
                 data = src.read()
                 transform = src.transform

--- a/georeader/rasterio_reader.py
+++ b/georeader/rasterio_reader.py
@@ -1,4 +1,5 @@
 import rasterio
+import rasterio.cache
 import rasterio.windows
 import numpy as np
 from typing import Tuple, Dict, List, Optional, Union, Any
@@ -15,12 +16,12 @@ from georeader.read import WEB_MERCATOR_CRS, SIZE_DEFAULT, window_from_tile, rea
 from numpy.typing import NDArray
 
 
-# CPL_VSIL_CURL_NON_CACHED configuration option can be set to values like 
-# /vsicurl/http://example.com/foo.tif:/vsicurl/http://example.com/some_directory, so that at file handle closing, 
-# all cached content related to the mentioned file(s) is no longer cached.
-# https://github.com/rasterio/rasterio/issues/1877
-# VSICurlClearCache()
-# https://github.com/rasterio/rasterio/blob/main/rasterio/_path.py
+# GDAL caches HTTP responses in a global LRU. When remote files are modified
+# externally, cached data can become stale, causing read errors or returning
+# old data. rasterio.cache.invalidate(path) clears cached responses for a
+# specific path. Set rio_env_options["invalidate_cache_before_open"] = True
+# to clear automatically before every open, or call reader.invalidate_cache().
+# See: https://rasterio.readthedocs.io/en/latest/api/rasterio.cache.html
 
 
 RIO_ENV_OPTIONS_DEFAULT = geotensor.RIO_ENV_OPTIONS_DEFAULT
@@ -58,7 +59,8 @@ class RasterioReader:
         Check all paths are OK.
     - rio_env_options : `Optional[Dict[str, str]]`
         GDAL options for reading. Defaults to: `RIO_ENV_OPTIONS_DEFAULT`. If you read rasters that might change
-        from a remote source, you might want to set `read_with_CPL_VSIL_CURL_NON_CACHED` to True.
+        from a remote source, set ``invalidate_cache_before_open`` to ``True`` to clear the HTTP cache before
+        each open, or call ``invalidate_cache()`` explicitly when needed.
 
     Attributes
     -------------------
@@ -309,15 +311,27 @@ class RasterioReader:
         return tags
 
     def _get_rio_options_path(self, path:str) -> Dict[str, str]:
-        options = self.rio_env_options
-        return geotensor.get_rio_options_path(options=options, path=path)
+        return geotensor._maybe_invalidate_cache(options=self.rio_env_options, path=path)
     
-    # This function does not work for e.g. returning the descriptions of the bands
-    # @contextmanager
-    # def _rio_open(self, path:str, mode:str="r", overview_level:Optional[int]=None) -> rasterio.DatasetReader:
-    #     with rasterio.Env(**self._get_rio_options_path(path)):
-    #         with rasterio.open(path, mode=mode, overview_level=overview_level) as src:
-    #             yield src
+    def invalidate_cache(self) -> None:
+        """Invalidate the HTTP cache for all paths in this reader.
+
+        Calls ``rasterio.cache.invalidate()`` for each remote path, clearing
+        any stale cached HTTP responses. Use this when remote files have changed
+        and you want to force fresh reads.
+        """
+        for p in self.paths:
+            if "://" in p:
+                rasterio.cache.invalidate(p)
+
+    @staticmethod
+    def invalidate_cache_all() -> None:
+        """Invalidate all HTTP cached responses globally.
+
+        Calls ``rasterio.cache.invalidate_all()``, clearing the entire
+        GDAL VSIL curl cache.
+        """
+        rasterio.cache.invalidate_all()
 
     @property
     def descriptions(self) -> Union[List[List[str]], List[str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["georeader/SolarIrradiance_Thuillier.csv"]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
-rasterio = ">=1"
+rasterio = ">=1.5.0"
 numpy = ">=1"
 shapely = ">=2"
 geopandas = ">=1"

--- a/tests/test_rasterio_reader.py
+++ b/tests/test_rasterio_reader.py
@@ -663,3 +663,47 @@ class TestRasterioReaderCopy:
         assert copy.window_focus == reader.window_focus
         assert copy.width == 100
         assert copy.height == 100
+
+
+class TestCacheInvalidation:
+    """Tests for rasterio.cache integration (issue #44)."""
+
+    def test_deprecated_option_warns(self, test_raster_path):
+        """read_with_CPL_VSIL_CURL_NON_CACHED emits DeprecationWarning."""
+        import pytest
+        from georeader.geotensor import RIO_ENV_OPTIONS_DEFAULT
+
+        options = dict(RIO_ENV_OPTIONS_DEFAULT)
+        options["read_with_CPL_VSIL_CURL_NON_CACHED"] = True
+
+        with pytest.warns(DeprecationWarning, match="invalidate_cache_before_open"):
+            rasterio_reader.RasterioReader(test_raster_path, rio_env_options=options)
+
+    def test_new_option_local_file(self, test_raster_path):
+        """invalidate_cache_before_open works (no-op) for local files."""
+        from georeader.geotensor import RIO_ENV_OPTIONS_DEFAULT
+
+        options = dict(RIO_ENV_OPTIONS_DEFAULT)
+        options["invalidate_cache_before_open"] = True
+        reader = rasterio_reader.RasterioReader(test_raster_path, rio_env_options=options)
+        data = reader.load()
+        assert data.shape == (15, 200, 250)
+
+    def test_option_stripped_from_env(self, test_raster_path):
+        """Custom keys are removed before passing to rasterio.Env."""
+        from georeader.geotensor import _maybe_invalidate_cache, RIO_ENV_OPTIONS_DEFAULT
+
+        options = dict(RIO_ENV_OPTIONS_DEFAULT)
+        options["invalidate_cache_before_open"] = True
+        clean = _maybe_invalidate_cache(options, test_raster_path)
+        assert "invalidate_cache_before_open" not in clean
+        assert "read_with_CPL_VSIL_CURL_NON_CACHED" not in clean
+
+    def test_invalidate_cache_method(self, test_raster_path):
+        """invalidate_cache() is callable without error on local paths."""
+        reader = rasterio_reader.RasterioReader(test_raster_path)
+        reader.invalidate_cache()
+
+    def test_invalidate_cache_all_method(self):
+        """invalidate_cache_all() is callable."""
+        rasterio_reader.RasterioReader.invalidate_cache_all()


### PR DESCRIPTION
## Summary

- Replace the ad-hoc `CPL_VSIL_CURL_NON_CACHED` env var workaround with `rasterio.cache.invalidate()`, available in rasterio 1.5.0+
- Delete `_vsi_path()` (no longer needed; rasterio.cache handles path translation internally)
- New option: `invalidate_cache_before_open` replaces `read_with_CPL_VSIL_CURL_NON_CACHED`
- New convenience methods: `RasterioReader.invalidate_cache()` and `RasterioReader.invalidate_cache_all()`
- Old option still works with a `DeprecationWarning`

Fixes #44

## Changes

| File | What changed |
|------|-------------|
| `pyproject.toml` | Bump rasterio to `>=1.5.0` |
| `georeader/geotensor.py` | Delete `_vsi_path()` and `get_rio_options_path()`, add `_maybe_invalidate_cache()` |
| `georeader/rasterio_reader.py` | Update `_get_rio_options_path()`, add `invalidate_cache()` + `invalidate_cache_all()` methods, update docstrings |
| `docs/advanced/error_read_write_in_remote_path.md` | Document new API, deprecation note |
| `tests/test_rasterio_reader.py` | 5 new tests for cache invalidation |

## Verified behavior

Tested against a remote HTTP server with file swapping to reproduce the GDAL VSIL cache staleness bug:

1. Read 3-band raster via HTTP, swap file to 1-band on server
2. Read without invalidation: **stale cache returned old 3-band data** (bug confirmed)
3. `rasterio.cache.invalidate(url)` then read: **got fresh 1-band data** (fix works)
4. `invalidate_cache_before_open=True` option: **auto-invalidation prevents stale reads**
5. `reader.invalidate_cache()` method: **explicit per-reader invalidation works**

## Test results

```
462 passed, 12 failed (pre-existing, missing optional deps), 10 skipped
```

Zero regressions vs main.