### PR TITLE
feat: add polygon_to_image_coords for inverse LUT mapping

### DIFF
--- a/georeader/griddata.py
+++ b/georeader/griddata.py
@@ -86,6 +86,7 @@ Grid Utilities:
     - :func:`meshgrid`: Generate coordinate arrays from transform
     - :func:`get_shape_transform_crs`: Compute output grid parameters
     - :func:`footprint`: Bounding polygon from lon/lat arrays
+    - :func:`polygon_to_image_coords`: Map a (lon, lat) polygon back to image (col, row) coordinates
 
 GLT Operations:
     - :func:`georreference`: Apply GLT for fast orthorectification
@@ -125,9 +126,9 @@ References
 - NASA EMIT L2A Products: https://lpdaac.usgs.gov/products/emitl2arflv001/
 """
 import georeader
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, MultiPolygon, LinearRing
 from georeader.abstract_reader import GeoData
-from scipy.interpolate import griddata
+from scipy.interpolate import griddata, LinearNDInterpolator, NearestNDInterpolator
 from georeader.window_utils import polygon_to_crs, transform_to_resolution_dst
 from typing import Tuple, Union, Optional, Any
 import rasterio
@@ -160,6 +161,147 @@ def footprint(lons:NDArray, lats:NDArray) -> Polygon:
     idxmaxlat = np.argmax(latsrav)
 
     return Polygon([(lonsrav[idx],latsrav[idx]) for idx in [idxminlon, idxminlat, idxmaxlon, idxmaxlat]])
+
+
+def polygon_to_image_coords(polygon: Union[Polygon, MultiPolygon],
+                            lons: NDArray, lats: NDArray,
+                            method: str = "linear") -> Union[Polygon, MultiPolygon]:
+    """
+    Map a polygon defined in the same CRS as ``lons``/``lats`` back to image
+    (column, row) coordinates of an irregularly-sampled image.
+
+    Inverts the per-pixel lon/lat lookup table so each polygon vertex is
+    expressed in pixel space: ``x = column``, ``y = row``. The resulting
+    geometry can be overlaid directly on the original ``(H, W)`` image (e.g.
+    via ``matplotlib.pyplot.imshow`` with ``origin="upper"``) without any
+    further reprojection.
+
+    Algorithm Overview
+    ------------------
+
+    ::
+
+        ┌────────────────────────────────────────────────────────────────────┐
+        │  POLYGON → IMAGE COORDINATE INVERSION                              │
+        │                                                                    │
+        │  Known per-pixel LUT:                                              │
+        │    pixel (r, c)  ──►  (lons[r, c], lats[r, c])                     │
+        │                                                                    │
+        │  We invert it at the polygon's vertices only:                      │
+        │    1. Build Delaunay triangulation of the H·W LUT points (once).   │
+        │    2. For each vertex (lon, lat), barycentric-interpolate          │
+        │       (col, row) within the enclosing triangle.                    │
+        │    3. Vertices outside the convex hull fall back to nearest-       │
+        │       neighbor lookup (linear method only).                        │
+        │                                                                    │
+        │  The triangulation is built once and reused across all rings of    │
+        │  all (multi)polygon parts.                                         │
+        │                                                                    │
+        └────────────────────────────────────────────────────────────────────┘
+
+    Args:
+        polygon: Shapely ``Polygon`` or ``MultiPolygon`` whose coordinates
+            share the CRS of ``lons``/``lats`` (typically EPSG:4326). Holes
+            (interior rings) are preserved.
+        lons: 2D array of pixel longitudes, shape ``(H, W)``.
+        lats: 2D array of pixel latitudes, shape ``(H, W)``.
+        method: Inversion method.
+
+            - ``"linear"`` (default): barycentric interpolation on a Delaunay
+              triangulation of the LUT. Sub-pixel accurate. Vertices outside
+              the convex hull of the LUT fall back to nearest-neighbor.
+            - ``"nearest"``: snap each vertex to the closest pixel index.
+              Faster and tolerant of vertices outside the LUT extent, but
+              yields integer-valued coordinates.
+
+    Returns:
+        Polygon or MultiPolygon (matching the input type) with vertices in
+        image ``(col, row)`` coordinates. An empty input returns an empty
+        geometry of the same type.
+
+    Raises:
+        ValueError: If ``method`` is not ``"linear"`` or ``"nearest"``, if
+            ``lons``/``lats`` have mismatched shapes, or if they are not 2D.
+        TypeError: If ``polygon`` is not a Polygon or MultiPolygon.
+
+    Examples
+    --------
+    Map a polygon to image coordinates and overlay on an image::
+
+        >>> import numpy as np
+        >>> from shapely.geometry import box
+        >>> from georeader.griddata import polygon_to_image_coords
+        >>>
+        >>> # Regular grid: lon spans [0, 1] over W=30, lat spans [45, 46] over H=20
+        >>> lons, lats = np.meshgrid(np.linspace(0, 1, 30), np.linspace(45, 46, 20))
+        >>> pol = box(0.0, 45.0, 0.5, 45.5)
+        >>> pol_img = polygon_to_image_coords(pol, lons, lats)
+        >>> # pol_img has x in [0, 14.5] (cols) and y in [0, 9.5] (rows)
+
+    See Also
+    --------
+    reproject : Forward direction (sensor → ortho via the same LUT).
+    footprint : Bounding polygon of the LUT in lon/lat space.
+    """
+    if method not in ("linear", "nearest"):
+        raise ValueError(
+            f"method must be 'linear' or 'nearest', got {method!r}"
+        )
+    if lons.shape != lats.shape:
+        raise ValueError(
+            f"lons and lats must share shape, got {lons.shape} vs {lats.shape}"
+        )
+    if lons.ndim != 2:
+        raise ValueError(f"lons and lats must be 2D, got ndim={lons.ndim}")
+    if not isinstance(polygon, (Polygon, MultiPolygon)):
+        raise TypeError(
+            f"polygon must be a Polygon or MultiPolygon, got {type(polygon).__name__}"
+        )
+
+    if polygon.is_empty:
+        return type(polygon)()
+
+    H, W = lons.shape
+    rows, cols = np.mgrid[0:H, 0:W]
+    pts = np.column_stack([lons.ravel(), lats.ravel()])
+    cols_flat = cols.ravel().astype(float)
+    rows_flat = rows.ravel().astype(float)
+
+    if method == "linear":
+        col_interp = LinearNDInterpolator(pts, cols_flat)
+        row_interp = LinearNDInterpolator(pts, rows_flat)
+        col_fallback = NearestNDInterpolator(pts, cols_flat)
+        row_fallback = NearestNDInterpolator(pts, rows_flat)
+    else:
+        col_interp = NearestNDInterpolator(pts, cols_flat)
+        row_interp = NearestNDInterpolator(pts, rows_flat)
+        col_fallback = None
+        row_fallback = None
+
+    def _ring_to_image(ring: LinearRing) -> LinearRing:
+        coords = np.asarray(ring.coords)
+        x = coords[:, 0]
+        y = coords[:, 1]
+        col = np.asarray(col_interp(x, y), dtype=float)
+        row = np.asarray(row_interp(x, y), dtype=float)
+        if col_fallback is not None:
+            nan = np.isnan(col) | np.isnan(row)
+            if nan.any():
+                col[nan] = col_fallback(x[nan], y[nan])
+                row[nan] = row_fallback(x[nan], y[nan])
+        return LinearRing(np.column_stack([col, row]))
+
+    def _polygon_to_image(poly: Polygon) -> Polygon:
+        if poly.is_empty:
+            return Polygon()
+        shell = _ring_to_image(poly.exterior)
+        holes = [_ring_to_image(interior) for interior in poly.interiors]
+        return Polygon(shell, holes)
+
+    if isinstance(polygon, Polygon):
+        return _polygon_to_image(polygon)
+
+    return MultiPolygon([_polygon_to_image(p) for p in polygon.geoms])
 
 
 # def bounds(lons:np.array, lats:np.array) -> Tuple[float, float, float, float]:

--- a/tests/test_griddata.py
+++ b/tests/test_griddata.py
@@ -11,6 +11,7 @@ These tests verify gridded data operations including:
 import numpy as np
 import pytest
 from rasterio.transform import from_origin
+from shapely.geometry import Polygon, MultiPolygon, box
 
 from georeader import griddata
 from georeader.geotensor import GeoTensor
@@ -237,3 +238,179 @@ class TestGeorreference:
         # Invalid areas should have fill value
         assert result.shape == data.shape
         assert isinstance(result, GeoTensor)
+
+
+class TestPolygonToImageCoords:
+    """Tests for polygon_to_image_coords function."""
+
+    @staticmethod
+    def _grid(H=20, W=30, lon_min=0.0, lon_max=1.0, lat_min=45.0, lat_max=46.0):
+        """
+        Build a regular lon/lat grid where the inverse mapping is closed-form:
+
+            col = (lon - lon_min) / (lon_max - lon_min) * (W - 1)
+            row = (lat - lat_min) / (lat_max - lat_min) * (H - 1)
+        """
+        lons, lats = np.meshgrid(
+            np.linspace(lon_min, lon_max, W),
+            np.linspace(lat_min, lat_max, H),
+        )
+        return lons, lats
+
+    def test_polygon_basic(self):
+        """Polygon vertices on grid lines should map to integer pixel coords."""
+        H, W = 20, 30
+        lons, lats = self._grid(H, W)
+
+        # box covering exactly half the grid extent in each axis
+        pol = box(0.0, 45.0, 0.5, 45.5)
+        result = griddata.polygon_to_image_coords(pol, lons, lats)
+
+        assert isinstance(result, Polygon)
+        assert not result.is_empty
+
+        xs, ys = result.exterior.coords.xy
+        xs = np.asarray(xs)
+        ys = np.asarray(ys)
+        # Expected pixel extent: col in [0, 14.5], row in [0, 9.5]
+        assert np.isclose(xs.min(), 0.0, atol=1e-6)
+        assert np.isclose(xs.max(), 14.5, atol=1e-6)
+        assert np.isclose(ys.min(), 0.0, atol=1e-6)
+        assert np.isclose(ys.max(), 9.5, atol=1e-6)
+
+    def test_polygon_preserves_holes(self):
+        """Interior rings (holes) should be transformed too."""
+        H, W = 20, 30
+        lons, lats = self._grid(H, W)
+
+        shell = [(0.0, 45.0), (1.0, 45.0), (1.0, 46.0), (0.0, 46.0)]
+        hole = [(0.25, 45.25), (0.75, 45.25), (0.75, 45.75), (0.25, 45.75)]
+        pol = Polygon(shell, [hole])
+
+        result = griddata.polygon_to_image_coords(pol, lons, lats)
+
+        assert isinstance(result, Polygon)
+        assert len(result.interiors) == 1
+
+        # Shell should span the full image extent
+        sx, sy = result.exterior.coords.xy
+        assert np.isclose(min(sx), 0.0, atol=1e-6)
+        assert np.isclose(max(sx), W - 1, atol=1e-6)
+        assert np.isclose(min(sy), 0.0, atol=1e-6)
+        assert np.isclose(max(sy), H - 1, atol=1e-6)
+
+        # Hole should be the inner box at 25%-75% of each axis
+        hx, hy = result.interiors[0].coords.xy
+        assert np.isclose(min(hx), 0.25 * (W - 1), atol=1e-6)
+        assert np.isclose(max(hx), 0.75 * (W - 1), atol=1e-6)
+        assert np.isclose(min(hy), 0.25 * (H - 1), atol=1e-6)
+        assert np.isclose(max(hy), 0.75 * (H - 1), atol=1e-6)
+
+    def test_multipolygon(self):
+        """MultiPolygon input should yield MultiPolygon output with same arity."""
+        H, W = 20, 30
+        lons, lats = self._grid(H, W)
+
+        a = box(0.0, 45.0, 0.25, 45.25)
+        b = box(0.75, 45.75, 1.0, 46.0)
+        mp = MultiPolygon([a, b])
+
+        result = griddata.polygon_to_image_coords(mp, lons, lats)
+
+        assert isinstance(result, MultiPolygon)
+        assert len(result.geoms) == 2
+
+        # First part: top-left quadrant of the image
+        ax, ay = result.geoms[0].exterior.coords.xy
+        assert np.isclose(min(ax), 0.0, atol=1e-6)
+        assert np.isclose(max(ax), 0.25 * (W - 1), atol=1e-6)
+        assert np.isclose(min(ay), 0.0, atol=1e-6)
+        assert np.isclose(max(ay), 0.25 * (H - 1), atol=1e-6)
+
+        # Second part: bottom-right quadrant
+        bx, by = result.geoms[1].exterior.coords.xy
+        assert np.isclose(min(bx), 0.75 * (W - 1), atol=1e-6)
+        assert np.isclose(max(bx), W - 1, atol=1e-6)
+        assert np.isclose(min(by), 0.75 * (H - 1), atol=1e-6)
+        assert np.isclose(max(by), H - 1, atol=1e-6)
+
+    def test_empty_polygon(self):
+        """Empty Polygon in -> empty Polygon out."""
+        lons, lats = self._grid()
+        result = griddata.polygon_to_image_coords(Polygon(), lons, lats)
+        assert isinstance(result, Polygon)
+        assert result.is_empty
+
+    def test_empty_multipolygon(self):
+        """Empty MultiPolygon in -> empty MultiPolygon out."""
+        lons, lats = self._grid()
+        result = griddata.polygon_to_image_coords(MultiPolygon(), lons, lats)
+        assert isinstance(result, MultiPolygon)
+        assert result.is_empty
+
+    def test_nearest_method_snaps_to_pixels(self):
+        """method='nearest' should yield integer-valued coordinates."""
+        H, W = 20, 30
+        lons, lats = self._grid(H, W)
+
+        # Vertices deliberately off-grid (between pixels)
+        pol = Polygon([
+            (0.012, 45.012),
+            (0.488, 45.012),
+            (0.488, 45.488),
+            (0.012, 45.488),
+        ])
+
+        result = griddata.polygon_to_image_coords(pol, lons, lats, method="nearest")
+        coords = np.asarray(result.exterior.coords)
+        # All values must be integer pixel indices
+        assert np.allclose(coords, np.round(coords))
+        # And within the image bounds
+        assert coords[:, 0].min() >= 0
+        assert coords[:, 0].max() <= W - 1
+        assert coords[:, 1].min() >= 0
+        assert coords[:, 1].max() <= H - 1
+
+    def test_vertex_outside_convex_hull_falls_back(self):
+        """A vertex outside the LUT extent should fall back to nearest pixel
+        instead of becoming NaN under method='linear'."""
+        H, W = 20, 30
+        lons, lats = self._grid(H, W)
+
+        # Far outside the grid (lon=2.0, lat=47.0 vs grid [0,1]x[45,46])
+        pol = Polygon([
+            (0.0, 45.0),
+            (2.0, 47.0),
+            (0.5, 45.5),
+        ])
+
+        result = griddata.polygon_to_image_coords(pol, lons, lats, method="linear")
+        coords = np.asarray(result.exterior.coords)
+        # No NaNs
+        assert np.isfinite(coords).all()
+        # The out-of-hull vertex snaps to the corner pixel (W-1, H-1)
+        assert np.isclose(coords[1, 0], W - 1, atol=1e-6)
+        assert np.isclose(coords[1, 1], H - 1, atol=1e-6)
+
+    def test_invalid_method_raises(self):
+        lons, lats = self._grid()
+        with pytest.raises(ValueError, match="method"):
+            griddata.polygon_to_image_coords(box(0, 45, 0.5, 45.5), lons, lats, method="cubic")
+
+    def test_shape_mismatch_raises(self):
+        lons = np.zeros((10, 20))
+        lats = np.zeros((20, 10))
+        with pytest.raises(ValueError, match="shape"):
+            griddata.polygon_to_image_coords(box(0, 0, 1, 1), lons, lats)
+
+    def test_non_2d_raises(self):
+        lons = np.zeros(10)
+        lats = np.zeros(10)
+        with pytest.raises(ValueError, match="2D"):
+            griddata.polygon_to_image_coords(box(0, 0, 1, 1), lons, lats)
+
+    def test_wrong_geometry_type_raises(self):
+        from shapely.geometry import Point
+        lons, lats = self._grid()
+        with pytest.raises(TypeError, match="Polygon or MultiPolygon"):
+            griddata.polygon_to_image_coords(Point(0.5, 45.5), lons, lats)


### PR DESCRIPTION
## Summary

Adds `polygon_to_image_coords` to `georeader.griddata`: inverts the per-pixel lon/lat lookup table at a polygon's vertices to express it in image `(col, row)` coordinates. Companion to `reproject` — same LUT, opposite direction.

- Accepts `Polygon` or `MultiPolygon`, returns the same type.
- Preserves interior rings (holes).
- Empty input → empty geometry of the same type.
- Builds the Delaunay triangulation **once** via `LinearNDInterpolator` and reuses it across all rings; vertices outside the convex hull fall back to nearest-neighbor under `method="linear"`.
- `method="nearest"` snaps to integer pixel indices.
- Raises `ValueError` on bad method / shape mismatch / non-2D LUTs and `TypeError` on non-(Multi)Polygon input.

## Test plan

New `TestPolygonToImageCoords` class in `tests/test_griddata.py`:

- [x] Basic polygon — vertices on a regular grid map to exact fractional pixel coords
- [x] Polygon with hole — both rings transformed
- [x] MultiPolygon — arity preserved, parts transformed independently
- [x] Empty `Polygon` → empty `Polygon`
- [x] Empty `MultiPolygon` → empty `MultiPolygon`
- [x] `method="nearest"` snaps to integer indices
- [x] Vertex outside the LUT convex hull falls back to nearest pixel (no NaN)
- [x] Invalid method raises `ValueError`
- [x] `lons`/`lats` shape mismatch raises `ValueError`
- [x] Non-2D `lons`/`lats` raises `ValueError`
- [x] Non-(Multi)Polygon input raises `TypeError`

---
_Generated by [Claude Code](https://claude.ai/code/session_015TGkPWzkwh7VUsQayXBXhY)_