### PR TITLE
feat: add strict fail-loud GeoTensor.values setter

### DIFF
--- a/georeader/geotensor.py
+++ b/georeader/geotensor.py
@@ -459,6 +459,40 @@ class GeoTensor(np.ndarray):
         """Return a view of the array (memory shared with original)"""
         return self.view(np.ndarray)
 
+    @values.setter
+    def values(self, new_values: NDArray) -> None:
+        """Write ``new_values`` into the existing buffer (in-place).
+
+        Because :class:`GeoTensor` *is* a numpy ndarray, the underlying buffer
+        cannot be rebound: only same-shape, same-dtype in-place writes are
+        allowed. Any shape or dtype mismatch raises immediately rather than
+        silently casting/truncating the data (e.g. float -> uint16).
+
+        Args:
+            new_values (NDArray): array matching ``self``; must have identical
+                shape and dtype.
+
+        Raises:
+            ValueError: if ``new_values.shape`` differs from ``self.shape``.
+            TypeError: if ``new_values.dtype`` differs from ``self.dtype``.
+        """
+        arr = np.asarray(new_values)
+        if arr.shape != self.shape:
+            raise ValueError(
+                f"Cannot set GeoTensor.values in place: shape {arr.shape} != {self.shape}. "
+                "GeoTensor is a numpy subclass and cannot change shape via assignment. "
+                "Build a new GeoTensor instead, e.g. "
+                "GeoTensor(arr, gt.transform, gt.crs, gt.fill_value_default), "
+                "or use slicing / .squeeze() which preserve georeferencing."
+            )
+        if arr.dtype != self.dtype:
+            raise TypeError(
+                f"Cannot set GeoTensor.values in place: dtype {arr.dtype} != {self.dtype}. "
+                "GeoTensor is a numpy subclass and cannot change dtype via assignment. "
+                "Use gt = gt.astype(dtype) to get a new GeoTensor with the desired dtype."
+            )
+        self[...] = arr
+
     @property
     def dims(self) -> Tuple[str]:
         # TODO allow different ordering of dimensions?

--- a/georeader/mosaic.py
+++ b/georeader/mosaic.py
@@ -335,8 +335,7 @@ def spatial_mosaic(data_list:Union[List[GeoData], List[Tuple[GeoData,GeoData]]],
         if masking_function is not None:
             invalid_geotensor = masking_function(invalid_geotensor)
 
-        invalid_geotensor.values = invalid_geotensor.values.astype(bool)
-        invalid_geotensor.values =  invalid_geotensor.values.squeeze()
+        invalid_geotensor = invalid_geotensor.astype(bool).squeeze()
         assert len(invalid_geotensor.shape) == 2, f"Invalid mask expected 2 dims found {invalid_geotensor.shape}"
 
         invalid_values|= invalid_geotensor.values
@@ -344,8 +343,7 @@ def spatial_mosaic(data_list:Union[List[GeoData], List[Tuple[GeoData,GeoData]]],
         # Apply masking funtion to the readed data
         invalid_geotensor = masking_function(data_return)
 
-        invalid_geotensor.values = invalid_geotensor.values.astype(bool)
-        invalid_geotensor.values = invalid_geotensor.values.squeeze()
+        invalid_geotensor = invalid_geotensor.astype(bool).squeeze()
         assert len(invalid_geotensor.shape) == 2, f"Invalid mask expected 2 dims found {invalid_geotensor.shape}"
         invalid_values |= invalid_geotensor.values
 
@@ -406,8 +404,7 @@ def spatial_mosaic(data_list:Union[List[GeoData], List[Tuple[GeoData,GeoData]]],
                 if masking_function is not None:
                     invalid_geotensor = masking_function(invalid_geotensor)
 
-                invalid_geotensor.values = invalid_geotensor.values.astype(bool)
-                invalid_geotensor.values = invalid_geotensor.values.squeeze()
+                invalid_geotensor = invalid_geotensor.astype(bool).squeeze()
                 assert len(invalid_geotensor.shape) == 2, f"Invalid mask expected 2 dims found {invalid_geotensor.shape}"
                 if np.all(invalid_geotensor.values):
                     continue
@@ -421,8 +418,7 @@ def spatial_mosaic(data_list:Union[List[GeoData], List[Tuple[GeoData,GeoData]]],
             if (geomask is None) and (masking_function is not None):
                 invalid_geotensor = masking_function(data_read)
 
-                invalid_geotensor.values = invalid_geotensor.values.astype(bool)
-                invalid_geotensor.values = invalid_geotensor.values.squeeze()
+                invalid_geotensor = invalid_geotensor.astype(bool).squeeze()
                 assert len(invalid_geotensor.shape) == 2, f"Invalid mask expected 2 dims found {invalid_geotensor.shape}"
                 if np.all(invalid_geotensor.values):
                     continue

--- a/georeader/readers/S2_SAFE_reader.py
+++ b/georeader/readers/S2_SAFE_reader.py
@@ -909,10 +909,12 @@ class S2Image:
     def load_mask(self) -> GeoTensor:
         reader_ref = self._get_reader()
         geotensor_ref = reader_ref.load(boundless=True)
-        geotensor_ref.values = (geotensor_ref.values == 0) | (
-            geotensor_ref.values == (2**16) - 1
-        )
-        return geotensor_ref
+        # Boolean mask from an integer band: build a new GeoTensor rather than
+        # assigning into .values (which forbids dtype changes in place).
+        mask = (geotensor_ref.values == 0) | (geotensor_ref.values == (2**16) - 1)
+        return GeoTensor(mask, transform=geotensor_ref.transform,
+                         crs=geotensor_ref.crs,
+                         fill_value_default=geotensor_ref.fill_value_default)
 
 
 class S2ImageL2A(S2Image):

--- a/georeader/readers/ee_image.py
+++ b/georeader/readers/ee_image.py
@@ -564,7 +564,9 @@ def interpolate_20mbands_s2ee(geotensor:GeoTensor,
     if need_pad:
         slice_rows = slice(pad_r[0], None if pad_r[1] <= 0 else -pad_r[1])
         slice_cols = slice(pad_c[0], None if pad_c[1] <= 0 else -pad_c[1])
-        b20ms2_20m10m.values = b20ms2_20m10m.values[(slice(None), slice_rows, slice_cols)]
+        # Slicing returns a new GeoTensor with an updated transform; assigning a
+        # cropped array into .values is rejected because the shape changes.
+        b20ms2_20m10m = b20ms2_20m10m[(slice(None), slice_rows, slice_cols)]
     
     geotensor.values[indexes_20m,...] = np.round(b20ms2_20m10m.values * 10_000).astype(np.uint16)
 

--- a/georeader/readers/enmap.py
+++ b/georeader/readers/enmap.py
@@ -707,8 +707,11 @@ class EnMAP:
             gain = self.gain_arr[name_coef]
             offset = self.offs_arr[name_coef]
             invalids = raster_product.values == raster_product.fill_value_default
-            raster_product.values = (
-                gain[:, np.newaxis, np.newaxis] * raster_product.values
+            # Arithmetic on a GeoTensor returns a new (float) GeoTensor preserving
+            # georeferencing; we cannot mutate .values in place here because the
+            # dtype changes from integer QCAL to float radiance.
+            raster_product = (
+                gain[:, np.newaxis, np.newaxis] * raster_product
                 + offset[:, np.newaxis, np.newaxis]
             ) * SC_COEFF
             raster_product.values[invalids] = self.fill_value_default

--- a/georeader/readers/probav_image_operational.py
+++ b/georeader/readers/probav_image_operational.py
@@ -369,9 +369,11 @@ class ProbaV:
         Returns:
             geotensor.GeoTensor: mask with the same shape as the image
         """
-        valids = self.load_sm(boundless=boundless)
-        valids.values = ~mask_only_sm(valids.values)
-        valids.fill_value_default = False
+        sm = self.load_sm(boundless=boundless)
+        # ~mask_only_sm(...) is boolean while sm is integer; build a new GeoTensor
+        # rather than assigning into .values (which forbids dtype changes in place).
+        valids = geotensor.GeoTensor(~mask_only_sm(sm.values), transform=sm.transform,
+                                     crs=sm.crs, fill_value_default=False)
         return valids
 
     def load_sm_cloud_mask(

--- a/georeader/readers/spotvgt_image_operational.py
+++ b/georeader/readers/spotvgt_image_operational.py
@@ -292,11 +292,12 @@ class SpotVGT:
         """
         
         sm = self.load_sm(boundless=boundless)
-        valids = sm.copy()
         invalids = mask_only_sm(sm.values)
-        valids.values = ~invalids
-        valids.fill_value_default = False
-        
+        # ~invalids is boolean while sm is integer; build a new GeoTensor rather
+        # than assigning into .values (which forbids dtype changes in place).
+        valids = geotensor.GeoTensor(~invalids, transform=sm.transform, crs=sm.crs,
+                                     fill_value_default=False)
+
         return valids
     
     def load_sm_cloud_mask(self, mask_undefined:bool=False, boundless:bool=True) -> geotensor.GeoTensor:

--- a/tests/test_geotensor.py
+++ b/tests/test_geotensor.py
@@ -1318,3 +1318,85 @@ class TestGeoTensorBitwiseOperations:
         assert isinstance(result, GeoTensor)
         expected = np.array([[True, True], [False, True]])
         assert np.array_equal(result.values, expected)
+
+
+class TestValuesSetter:
+    """Tests for the strict (fail-loud) GeoTensor.values setter."""
+
+    def _gt(self, shape=(3, 4, 5), dtype=np.float32):
+        data = np.arange(int(np.prod(shape)), dtype=dtype).reshape(shape)
+        transform = from_origin(0, shape[-2], 1, 1)
+        return GeoTensor(data, transform=transform, crs="EPSG:32631", fill_value_default=0)
+
+    def test_inplace_same_shape_and_dtype(self):
+        """Same shape and dtype writes through into the existing buffer."""
+        gt = self._gt()
+        new = np.ones_like(gt.values)
+        gt.values = new
+        assert np.array_equal(gt.values, new)
+        assert gt.dtype == np.float32
+
+    def test_inplace_writes_through_buffer(self):
+        """The write mutates the underlying buffer (no rebinding to a new array)."""
+        gt = self._gt()
+        view = gt.values  # shares memory with gt
+        gt.values = np.full(gt.shape, 7.0, dtype=np.float32)
+        # The pre-existing view sees the mutation -> same buffer was written.
+        assert np.all(view == 7.0)
+
+    def test_inplace_preserves_metadata(self):
+        """Setting values must not touch transform / crs / fill_value_default."""
+        gt = self._gt()
+        transform, crs, fill = gt.transform, gt.crs, gt.fill_value_default
+        gt.values = np.zeros(gt.shape, dtype=np.float32)
+        assert gt.transform == transform
+        assert gt.crs == crs
+        assert gt.fill_value_default == fill
+
+    def test_accepts_array_like(self):
+        """A non-ndarray array-like of matching shape/dtype is accepted."""
+        # Python float lists become float64 via np.asarray, so use a float64 tensor.
+        gt = self._gt(shape=(2, 2), dtype=np.float64)
+        gt.values = [[1.0, 2.0], [3.0, 4.0]]
+        assert np.array_equal(gt.values, np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+    def test_shape_mismatch_raises(self):
+        """A shape change is rejected loudly instead of silently failing."""
+        gt = self._gt(shape=(3, 4, 5))
+        with pytest.raises(ValueError, match="shape"):
+            gt.values = np.ones((4, 5), dtype=np.float32)
+
+    def test_squeeze_shape_change_raises(self):
+        """Assigning a squeezed array (shape change) raises rather than corrupts."""
+        gt = self._gt(shape=(1, 4, 5))
+        with pytest.raises(ValueError, match="shape"):
+            gt.values = gt.values.squeeze()
+
+    def test_dtype_mismatch_raises_no_silent_cast(self):
+        """A dtype change must raise rather than silently cast/truncate."""
+        gt = self._gt(shape=(2, 3), dtype=np.uint16)
+        # Float radiance into a uint16 buffer would silently truncate -> forbidden.
+        with pytest.raises(TypeError, match="dtype"):
+            gt.values = np.array([[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]], dtype=np.float64)
+
+    def test_bool_into_int_raises(self):
+        """Assigning a boolean mask into an integer GeoTensor raises (dtype change)."""
+        gt = self._gt(shape=(4, 5), dtype=np.uint8)
+        with pytest.raises(TypeError, match="dtype"):
+            gt.values = gt.values > 2
+
+    def test_item_assignment_still_works(self):
+        """In-place item/mask assignment (not the setter) is unaffected."""
+        gt = self._gt(shape=(4, 5), dtype=np.float32)
+        mask = gt.values > 10
+        gt.values[mask] = -1.0
+        assert np.all(gt.values[mask] == -1.0)
+
+    def test_astype_is_the_dtype_change_path(self):
+        """astype() returns a new GeoTensor with the new dtype, preserving georef."""
+        gt = self._gt(shape=(2, 3), dtype=np.uint16)
+        gt2 = gt.astype(np.float32)
+        assert isinstance(gt2, GeoTensor)
+        assert gt2.dtype == np.float32
+        assert gt2.transform == gt.transform
+        assert gt2.crs == gt.crs


### PR DESCRIPTION
## Problem

In georeader v2.0, `GeoTensor` became a subclass of `np.ndarray` and `values` became a **read-only property**. Code that previously rebound `gt.values = new_array` (e.g. [`enmap.py` `load_product`](georeader/readers/enmap.py)) now raises `AttributeError: can't set attribute`.

The dangerous part: simply adding a setter that does `self[...] = value` would **silently corrupt data**. Because a `GeoTensor` *is* the ndarray, its buffer/dtype/shape can't be rebound — an in-place write of a float radiance array into a `uint16` buffer would silently truncate, and shape changes (squeeze, slice, concatenate) can't happen in place at all.

## Fix

Add a `values` setter that allows **only true in-place writes** — identical shape **and** dtype — and otherwise **raises loudly**:
- shape mismatch → `ValueError`
- dtype mismatch → `TypeError`

Both messages tell the caller to build a new `GeoTensor` or use `.astype()` / slicing. No assignment can ever silently cast or truncate.

Refactor the internal call sites that genuinely changed shape/dtype:
- **enmap** — int→float radiance via GeoTensor arithmetic (returns a new float GeoTensor preserving georef)
- **mosaic** — `invalid_geotensor.astype(bool).squeeze()`
- **ee_image** — crop via slicing (auto-updates the transform)
- **spotvgt / probav / S2_SAFE_reader** — bool-from-int masks now build a fresh bool `GeoTensor`

## Tests

New `TestValuesSetter` (10 cases): in-place success, buffer write-through, metadata preservation, array-like acceptance, and the four fail-loud paths (shape change, squeeze, float→int, bool→int), plus confirming `gt.values[mask] = x` item-assignment and `astype()` still work.

`poetry run pytest tests/` → **870 passed**.

> Note: this is georeader-only. Downstream `marsml` has ~15 dtype/shape-changing `.values =` sites that will now raise loudly against this change and need the same one-line rewrites when the dependency is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)