### PR TITLE
fix(rasterio_reader): mask Azure SAS token signature in __repr__

### DIFF
--- a/georeader/rasterio_reader.py
+++ b/georeader/rasterio_reader.py
@@ -149,6 +149,7 @@ References
 - Cloud Optimized GeoTIFF: https://cogeo.org/
 - GDAL VSI: https://gdal.org/user/virtual_file_systems.html
 """
+import re
 import rasterio
 import rasterio.windows
 import numpy as np
@@ -175,6 +176,32 @@ from numpy.typing import NDArray
 
 
 RIO_ENV_OPTIONS_DEFAULT = geotensor.RIO_ENV_OPTIONS_DEFAULT
+
+
+# Azure Blob Storage URLs carry a Shared Access Signature (SAS) as a query
+# string, e.g.
+#   https://<account>.blob.core.windows.net/<container>/<path>.tif?sv=...&se=...&sig=<secret>
+# The `sig` parameter is the actual cryptographic signature of the token: anyone
+# holding it can access the resource for the lifetime of the SAS. The other
+# parameters (signed version `sv`, expiry `se`, permissions `sp`, ...) are not
+# secret, so we keep them to preserve useful context (e.g. the expiry time) and
+# only mask `sig`. The lookbehind keeps the match surgical so nothing else in the
+# URL is altered.
+_SAS_SIGNATURE_RE = re.compile(r"(?i)(?<=[?&]sig=)[^&]+")
+
+
+def mask_sas_token(path: Any) -> Any:
+    """Mask the signature of an Azure SAS token embedded in a file path.
+
+    Replaces the value of the ``sig`` query parameter with ``****`` so that the
+    secret signature of an Azure Shared Access Signature does not leak into
+    ``repr``/log output. Non-string inputs and paths without a SAS signature are
+    returned unchanged. The expiry (``se``) and other non-secret parameters are
+    preserved.
+    """
+    if not isinstance(path, str):
+        return path
+    return _SAS_SIGNATURE_RE.sub("****", path)
 
 class RasterioReader:
     """
@@ -1202,8 +1229,9 @@ class RasterioReader:
         return griddata.meshgrid(self.transform, self.width, self.height, source_crs=self.crs, dst_crs=dst_crs)
     
     def __repr__(self)->str:
-        return f""" 
-         Paths: {self.paths}
+        paths = [mask_sas_token(p) for p in self.paths]
+        return f"""
+         Paths: {paths}
          Transform: {self.transform}
          Shape: {self.shape}
          Resolution: {self.res}

--- a/tests/test_rasterio_reader.py
+++ b/tests/test_rasterio_reader.py
@@ -663,3 +663,59 @@ class TestRasterioReaderCopy:
         assert copy.window_focus == reader.window_focus
         assert copy.width == 100
         assert copy.height == 100
+
+
+# Example expiry/start times and signature kept separate so the secret value is
+# only ever assembled inside the tests.
+_SAS_QUERY = (
+    "sv=2021-08-06&st=2024-01-01T00%3A00%3A00Z&se=2024-12-31T23%3A59%3A59Z"
+    "&sr=b&sp=r&sig=abc123SECRETsignatureValue%2Fwith%2Bchars%3D"
+)
+_AZURE_SAS_URL = (
+    "https://myaccount.blob.core.windows.net/mycontainer/path/to/file.tif?"
+    + _SAS_QUERY
+)
+
+
+class TestMaskSasToken:
+    """Tests for masking Azure SAS token signatures in paths."""
+
+    def test_masks_signature(self):
+        masked = rasterio_reader.mask_sas_token(_AZURE_SAS_URL)
+        assert "abc123SECRETsignatureValue" not in masked
+        assert "sig=****" in masked
+
+    def test_keeps_expiry_and_host(self):
+        masked = rasterio_reader.mask_sas_token(_AZURE_SAS_URL)
+        # Non-secret context is preserved so logs stay useful.
+        assert "se=2024-12-31T23%3A59%3A59Z" in masked
+        assert "myaccount.blob.core.windows.net/mycontainer/path/to/file.tif" in masked
+        assert "sv=2021-08-06" in masked
+
+    def test_signature_in_middle_of_query(self):
+        url = (
+            "https://acct.blob.core.windows.net/c/f.tif?"
+            "sig=SECRETvalue&se=2024-12-31T23%3A59%3A59Z"
+        )
+        masked = rasterio_reader.mask_sas_token(url)
+        assert "SECRETvalue" not in masked
+        assert "sig=****" in masked
+        assert "se=2024-12-31T23%3A59%3A59Z" in masked
+
+    def test_path_without_token_unchanged(self):
+        path = "https://acct.blob.core.windows.net/c/f.tif"
+        assert rasterio_reader.mask_sas_token(path) == path
+
+    def test_local_path_unchanged(self):
+        path = "/data/images/file.tif"
+        assert rasterio_reader.mask_sas_token(path) == path
+
+    def test_non_string_unchanged(self):
+        assert rasterio_reader.mask_sas_token(None) is None
+
+    def test_repr_masks_signature(self, test_raster_path):
+        reader = rasterio_reader.RasterioReader(test_raster_path)
+        reader.paths = [_AZURE_SAS_URL]
+        text = repr(reader)
+        assert "abc123SECRETsignatureValue" not in text
+        assert "sig=****" in text


### PR DESCRIPTION
## Summary

When reading files from Azure Blob Storage, paths look like:

```
https://<account>.blob.core.windows.net/<container>/<path>.tif?sv=...&se=...&sig=<secret>
```

The `sig` query parameter is the cryptographic **signature** of the Shared Access Signature (SAS) — anyone holding it can access the resource until the SAS expires. `RasterioReader.__repr__` prints `self.paths`, so this secret could end up in **log files**.

This PR masks the SAS signature in the repr while keeping the rest of the URL intact (host, container, path, and non-secret params like `se` expiry / `sv` version), so logs stay useful but safe.

## Changes

- Add `mask_sas_token(path)` helper in `georeader/rasterio_reader.py`. It replaces the value of the `sig` query parameter with `****` using a surgical regex (case-insensitive, anchored to `?sig=`/`&sig=`). Non-string inputs and paths without a SAS signature are returned unchanged.
- Use it in `RasterioReader.__repr__` to mask each path.
- Add tests (`TestMaskSasToken`) covering signature masking, expiry/host preservation, signature anywhere in the query, non-SAS/local paths, non-string inputs, and the `repr` output.

## Example

Before:
```
Paths: ['https://acct.blob.core.windows.net/c/f.tif?sv=2021-08-06&se=2024-12-31T23%3A59%3A59Z&sig=abc123SECRET...']
```

After:
```
Paths: ['https://acct.blob.core.windows.net/c/f.tif?sv=2021-08-06&se=2024-12-31T23%3A59%3A59Z&sig=****']
```

## Notes

- Only the secret `sig` is masked; the expiry time (`se`) is intentionally preserved, as requested.
- The 2 pre-existing `meshgrid` test failures locally are due to `scipy` not being installed in the scratch env and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdcL5Yf9jiP98cFsF2JqvQ)_