### PR TITLE
fix(ee_query): drop degenerate whole-globe footprints

### DIFF
--- a/georeader/readers/ee_query.py
+++ b/georeader/readers/ee_query.py
@@ -445,6 +445,48 @@ def images_by_query_grid(images_available_gee:gpd.GeoDataFrame, grid:gpd.GeoData
     aois_images = aois_images.loc[indexes_selected].copy()
     return aois_images.reset_index(drop=True)
 
+DEGENERATE_FOOTPRINT_MAX_LAT_SPAN = 5.0
+
+
+def _filter_degenerate_footprints(geodf: gpd.GeoDataFrame,
+                                  max_lat_span: float = DEGENERATE_FOOTPRINT_MAX_LAT_SPAN
+                                  ) -> gpd.GeoDataFrame:
+    """
+    Drop rows whose footprint spans an implausibly large latitude range.
+
+    Some Earth Engine assets (e.g. certain real-time Landsat products) return a corrupt
+    ``system:footprint`` that degrades to the whole globe (``[-180, -90, 180, 90]``). Such a
+    footprint intersects every AOI, yielding a bogus 100% ``overlappercentage`` and polluting
+    the query results. A genuine S1/S2/Landsat scene spans at most ~3 deg of latitude
+    (latitude span is pole-robust, unlike longitude), so a latitude span above
+    ``max_lat_span`` (default 5 deg) reliably flags these corrupt footprints while staying
+    well clear of valid high-latitude scenes.
+
+    Args:
+        geodf (gpd.GeoDataFrame): query results with a ``geometry`` column (EPSG:4326).
+        max_lat_span (float): maximum footprint latitude span in degrees. Defaults to 5.
+
+    Returns:
+        gpd.GeoDataFrame: ``geodf`` without the degenerate-footprint rows.
+    """
+    if geodf.shape[0] == 0:
+        return geodf
+    lat_span = geodf.geometry.apply(
+        lambda g: (g.bounds[3] - g.bounds[1]) if (g is not None and not g.is_empty) else 0.0
+    )
+    degenerate = lat_span > max_lat_span
+    if degenerate.any():
+        for idx in geodf.index[degenerate]:
+            warnings.warn(
+                f"Dropping image {idx!r} with degenerate footprint (latitude span "
+                f"{lat_span[idx]:.1f} deg > {max_lat_span} deg); likely corrupt "
+                "system:footprint metadata from Earth Engine.",
+                stacklevel=2,
+            )
+        geodf = geodf[~degenerate]
+    return geodf
+
+
 def _add_stuff(geodf, area, tz):
     geodf["utcdatetime"] = pd.to_datetime(geodf["system:time_start"], unit='ms', utc=True)
     geodf["overlappercentage"] = geodf.geometry.apply(lambda x: overlappercentage_safe(x, area))
@@ -456,6 +498,7 @@ def _add_stuff(geodf, area, tz):
                                             utc=True).dt.tz_convert(tz)
     geodf["satellite"] = [x.split("_")[0] for x in geodf["title"]]
     geodf = geodf.set_index("title", drop=True)
+    geodf = _filter_degenerate_footprints(geodf)
 
     return geodf
 

--- a/tests/readers/test_ee_query_degenerate.py
+++ b/tests/readers/test_ee_query_degenerate.py
@@ -10,6 +10,8 @@ import geopandas as gpd
 import pytest
 from shapely.geometry import Polygon, box
 
+pytest.importorskip("ee", reason="earthengine-api required for ee_query tests")
+
 from georeader.readers.ee_query import (
     DEGENERATE_FOOTPRINT_MAX_LAT_SPAN,
     _filter_degenerate_footprints,

--- a/tests/readers/test_ee_query_degenerate.py
+++ b/tests/readers/test_ee_query_degenerate.py
@@ -1,0 +1,72 @@
+"""Tests for the degenerate-footprint guard in georeader.readers.ee_query.
+
+Drop this file into ``georeader/tests/readers/`` and run with the earthengine-api extra
+installed (``ee_query`` imports ``ee`` at module load):
+
+    poetry run pytest tests/readers/test_ee_query_degenerate.py -v
+"""
+import warnings
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon, box
+
+from georeader.readers.ee_query import (
+    DEGENERATE_FOOTPRINT_MAX_LAT_SPAN,
+    _filter_degenerate_footprints,
+)
+
+# Real ~185 km scene (northern Fennoscandia) — ~2.4 deg latitude span.
+NORMAL = box(21.28, 67.04, 27.88, 69.46)
+# Corrupt whole-globe footprint returned by GEE for LC08_193012_20260627.
+WORLD = box(-180, -90, 180, 90)
+
+
+def _gdf(rows):
+    return gpd.GeoDataFrame(
+        {"geometry": [g for _, g in rows]},
+        index=[t for t, _ in rows],
+        crs="EPSG:4326",
+    )
+
+
+def test_default_threshold_is_5_degrees():
+    assert DEGENERATE_FOOTPRINT_MAX_LAT_SPAN == 5.0
+
+
+def test_drops_world_footprint_and_keeps_normal():
+    gdf = _gdf([("normal", NORMAL), ("corrupt", WORLD)])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = _filter_degenerate_footprints(gdf)
+    assert list(out.index) == ["normal"]
+
+
+def test_warns_on_dropped_tile():
+    gdf = _gdf([("corrupt", WORLD)])
+    with pytest.warns(UserWarning, match="degenerate footprint"):
+        out = _filter_degenerate_footprints(gdf)
+    assert len(out) == 0
+
+
+def test_keeps_wide_low_latitude_span_scene():
+    # A large-longitude / high-latitude scene (e.g. S1) with small latitude span is kept.
+    wide = box(10.0, 60.0, 40.0, 62.5)  # 2.5 deg lat span
+    assert list(_filter_degenerate_footprints(_gdf([("s1", wide)])).index) == ["s1"]
+
+
+def test_empty_geodataframe_returned_unchanged():
+    assert len(_filter_degenerate_footprints(gpd.GeoDataFrame({"geometry": []}, crs="EPSG:4326"))) == 0
+
+
+def test_empty_geometry_is_kept():
+    assert list(_filter_degenerate_footprints(_gdf([("empty", Polygon())])).index) == ["empty"]
+
+
+def test_custom_threshold():
+    span3 = box(0.0, 40.0, 1.0, 43.0)  # 3 deg lat span
+    assert list(_filter_degenerate_footprints(_gdf([("s", span3)])).index) == ["s"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = _filter_degenerate_footprints(_gdf([("s", span3)]), max_lat_span=2.0)
+    assert len(out) == 0

--- a/tests/readers/test_ee_query_degenerate.py
+++ b/tests/readers/test_ee_query_degenerate.py
@@ -1,7 +1,6 @@
 """Tests for the degenerate-footprint guard in georeader.readers.ee_query.
 
-Drop this file into ``georeader/tests/readers/`` and run with the earthengine-api extra
-installed (``ee_query`` imports ``ee`` at module load):
+Run with the earthengine-api extra installed (``ee_query`` imports ``ee`` at module load):
 
     poetry run pytest tests/readers/test_ee_query_degenerate.py -v
 """


### PR DESCRIPTION
Some Earth Engine assets (certain real-time Landsat products) return a corrupt `system:footprint` that degrades to the whole globe (`[-180,-90,180,90]`), giving a bogus 100% overlap that pollutes query results.

`_add_stuff` now drops rows whose footprint latitude span > 5° (`_filter_degenerate_footprints`) — flagging corrupt footprints while staying clear of valid high-latitude S1/S2/Landsat scenes.

Tests added (`tests/readers/test_ee_query_degenerate.py`).